### PR TITLE
Added support for java-client 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,22 @@ Ensure that @ symbol is prepended to the file path in the above request. Please 
 
 Local Testing is a BrowserStack feature that helps you test mobile apps that access resources hosted in development or testing environments during automated test execution
 
-To setup Local Testing connection - [Local testing reference](https://www.browserstack.com/docs/app-automate/appium/getting-started/java/local-testing)
+**i. Setup Browserstack Local Testing connection :**
 
-NOTE : If you're unable to run the LocalTesting Binary due to Apple permission issues, go to \
+Check the releases page to download the binary / native application [Browserstack Local Releases](https://www.browserstack.com/docs/local-testing/releases-and-downloads)
+
+- Option 1
+    - Use Browserstack Local Binary - [Local Binary](https://www.browserstack.com/docs/app-automate/appium/getting-started/java/local-testing)
+- Option 2
+    - Use Browserstack native application - [Local Native App](https://www.browserstack.com/docs/local-testing/local-app-upgrade-guide)
+
+
+NOTE : If you're unable to run the LocalTesting Binary / Native application due to Apple permission issues, go to \
     ```
         System preferences -> Security and privacy -> General -> Allow app
     ```
 
-Open `BrowserStackSampleLocal.java` file in the `android` or `ios` directory :
+**ii. Open `BrowserStackSampleLocal.java` file in the `android` or `ios` directory :**
 
 - Replace `YOUR_USERNAME` & `YOUR_ACCESS_KEY` with your BrowserStack access credentials. Get your BrowserStack access credentials from [here](https://www.browserstack.com/accounts/settings)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ Ensure that @ symbol is prepended to the file path in the above request. Please 
 
 **2. Configure and run your local test**
 
+Local Testing is a BrowserStack feature that helps you test mobile apps that access resources hosted in development or testing environments during automated test execution
+
+To setup Local Testing connection - [Local testing reference](https://www.browserstack.com/docs/app-automate/appium/getting-started/java/local-testing)
+
+NOTE : If you're unable to run the LocalTesting Binary due to Apple permission issues, go to \
+    ```
+        System preferences -> Security and privacy -> General -> Allow app
+    ```
+
 Open `BrowserStackSampleLocal.java` file in the `android` or `ios` directory :
 
 - Replace `YOUR_USERNAME` & `YOUR_ACCESS_KEY` with your BrowserStack access credentials. Get your BrowserStack access credentials from [here](https://www.browserstack.com/accounts/settings)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ mvn clean install
 
 Getting Started with Appium tests in Java on BrowserStack couldn't be easier!
 
-For java-client 8.0.0 and above
-NOTE : Any BrowserStack capability passed outside bstack:options will not be honoured.
+### For java-client 8.0.0 and above
+
+NOTE : Any BrowserStack capability passed outside bstack:options will not be honoured \
 [Browserstack Capability Builder](https://www.browserstack.com/app-automate/capabilities?tag=w3c)
 
 ### Run your first test :

--- a/README.md
+++ b/README.md
@@ -34,23 +34,18 @@ Getting Started with Appium tests in Java on BrowserStack couldn't be easier!
 - Any BrowserStack capability passed outside bstack:options will not be honoured \
 [Browserstack Capability Builder](https://www.browserstack.com/app-automate/capabilities?tag=w3c)
 
-- AppiumBy is available with java-client 8.0.0 . For java-client < 8.0.0, MobileBy can be used.
+- AppiumBy is available with java-client 8.0.0 as MobileBy is depreceated . For java-client < 8.0.0, MobileBy can be used.
 
 - WebDriverWait constructor requires time to be passed as a type Duration. So with java-client 8.0.0, pass wait time as a new Duration
--   java-client v-7.0.0
+    **java-client v-7.0.0**
     ```
-     WebElement searchElement = (WebElement) new WebDriverWait(
-      driver,
-      30
-    )
+     WebElement searchElement = (WebElement) new WebDriverWait(driver, 30)
     ```
     
-    java-client v-8.0.0
+    **java-client v-8.0.0**
     ```
-     WebElement searchElement = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
+     import java.time.Duration;
+     WebElement searchElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
     ```
     
   Refer this for tracking changes in java-client 8.0.0 documentation - [v7-to-v8-migration-guide](https://github.com/appium/java-client/blob/master/docs/v7-to-v8-migration-guide.md#mobileelement)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ mvn clean install
 
 Getting Started with Appium tests in Java on BrowserStack couldn't be easier!
 
+For java-client 8.0.0 and above
+NOTE : Any BrowserStack capability passed outside bstack:options will not be honoured.
+[Browserstack Capability Builder](https://www.browserstack.com/app-automate/capabilities?tag=w3c)
+
 ### Run your first test :
 
 **1. Upload your Android or iOS App**

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Getting Started with Appium tests in Java on BrowserStack couldn't be easier!
 
 - AppiumBy is available with java-client 8.0.0 as MobileBy is depreceated . For java-client < 8.0.0, MobileBy can be used.
 
+- DefaultGenericMobileElement class has been removed completely together with its descendants (MobileElement, IOSElement, AndroidElement etc.). Use WebElement instead.
+
 - WebDriverWait constructor requires time to be passed as a type Duration. So with java-client 8.0.0, pass wait time as a new Duration
     **java-client v-7.0.0**
     ```

--- a/README.md
+++ b/README.md
@@ -31,8 +31,29 @@ Getting Started with Appium tests in Java on BrowserStack couldn't be easier!
 
 ### For java-client 8.0.0 and above
 
-NOTE : Any BrowserStack capability passed outside bstack:options will not be honoured \
+- Any BrowserStack capability passed outside bstack:options will not be honoured \
 [Browserstack Capability Builder](https://www.browserstack.com/app-automate/capabilities?tag=w3c)
+
+- AppiumBy is available with java-client 8.0.0 . For java-client < 8.0.0, MobileBy can be used.
+
+- WebDriverWait constructor requires time to be passed as a type Duration. So with java-client 8.0.0, pass wait time as a new Duration
+-   java-client v-7.0.0
+    ```
+     WebElement searchElement = (WebElement) new WebDriverWait(
+      driver,
+      30
+    )
+    ```
+    
+    java-client v-8.0.0
+    ```
+     WebElement searchElement = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
+    ```
+    
+  Refer this for tracking changes in java-client 8.0.0 documentation - [v7-to-v8-migration-guide](https://github.com/appium/java-client/blob/master/docs/v7-to-v8-migration-guide.md#mobileelement)
 
 ### Run your first test :
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>io.appium</groupId>
 			<artifactId>java-client</artifactId>
-			<version>7.0.0</version>
+			<version>8.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.browserstack</groupId>

--- a/src/test/java/android/BrowserStackSample.java
+++ b/src/test/java/android/BrowserStackSample.java
@@ -5,14 +5,14 @@ import java.util.List;
 import java.util.function.Function;
 import java.net.MalformedURLException;
 
-import io.appium.java_client.MobileBy;
-import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidElement;
-
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import io.appium.java_client.AppiumBy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 
 public class BrowserStackSample {
@@ -40,23 +40,23 @@ public class BrowserStackSample {
     	
     	// Initialise the remote Webdriver using BrowserStack remote URL
     	// and desired capabilities defined above
-        AndroidDriver<AndroidElement> driver = new AndroidDriver<AndroidElement>(
+        RemoteWebDriver driver = new RemoteWebDriver(
         		new URL("http://hub.browserstack.com/wd/hub"), caps);
-        
+       
 
         // Test case for the BrowserStack sample Android app. 
         // If you have uploaded your app, update the test case here. 
-        AndroidElement searchElement = (AndroidElement) new WebDriverWait(driver, 30).until(
+        WebElement searchElement = (WebElement) new WebDriverWait(driver, 30).until(
             ExpectedConditions.elementToBeClickable(
-            		MobileBy.AccessibilityId("Search Wikipedia")));
+            		AppiumBy.accessibilityId("Search Wikipedia")));
         searchElement.click();
-		AndroidElement insertTextElement = (AndroidElement) new WebDriverWait(driver, 30).until(
+		WebElement insertTextElement = (WebElement) new WebDriverWait(driver, 30).until(
              ExpectedConditions.elementToBeClickable(
-            		 MobileBy.id("org.wikipedia.alpha:id/search_src_text")));
+            		 AppiumBy.id("org.wikipedia.alpha:id/search_src_text")));
         insertTextElement.sendKeys("BrowserStack");
         Thread.sleep(5000);
-        List<AndroidElement> allProductsName = driver.findElementsByClassName(
-        		"android.widget.TextView");
+        List<WebElement> allProductsName = driver.findElements(AppiumBy.className("android.widget.TextView"));
+        		
         assert(allProductsName.size() > 0);
         
         

--- a/src/test/java/android/BrowserStackSample.java
+++ b/src/test/java/android/BrowserStackSample.java
@@ -5,15 +5,14 @@ import java.util.List;
 import java.util.function.Function;
 import java.net.MalformedURLException;
 
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import org.openqa.selenium.remote.DesiredCapabilities;
-
 import io.appium.java_client.AppiumBy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class BrowserStackSample {
 
@@ -23,26 +22,24 @@ public class BrowserStackSample {
     	
     	// Set your access credentials
     	caps.setCapability("browserstack.user", "YOUR_USERNAME");
-    	caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
+		caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
     	
     	// Set URL of the application under test
     	caps.setCapability("app", "bs://<app-id>");
     	
-    	// Specify device and os_version for testing
-    	caps.setCapability("device", "Google Pixel 3");
-    	caps.setCapability("os_version", "9.0");
+    	// Specify deviceName and platformName for testing
+    	caps.setCapability("deviceName", "Google Pixel 3");
+		caps.setCapability("platformName", "android");
+    	caps.setCapability("platformVersion", "9.0");
         
     	// Set other BrowserStack capabilities
     	caps.setCapability("project", "First Java Project");
     	caps.setCapability("build", "browserstack-build-1");
     	caps.setCapability("name", "first_test");
        
-    	
     	// Initialise the remote Webdriver using BrowserStack remote URL
     	// and desired capabilities defined above
-        RemoteWebDriver driver = new RemoteWebDriver(
-        		new URL("http://hub.browserstack.com/wd/hub"), caps);
-       
+    	RemoteWebDriver driver = new RemoteWebDriver(new URL("http://hub.browserstack.com/wd/hub"), caps);
 
         // Test case for the BrowserStack sample Android app. 
         // If you have uploaded your app, update the test case here. 
@@ -50,15 +47,15 @@ public class BrowserStackSample {
             ExpectedConditions.elementToBeClickable(
             		AppiumBy.accessibilityId("Search Wikipedia")));
         searchElement.click();
+
 		WebElement insertTextElement = (WebElement) new WebDriverWait(driver, 30).until(
              ExpectedConditions.elementToBeClickable(
             		 AppiumBy.id("org.wikipedia.alpha:id/search_src_text")));
         insertTextElement.sendKeys("BrowserStack");
         Thread.sleep(5000);
+
         List<WebElement> allProductsName = driver.findElements(AppiumBy.className("android.widget.TextView"));
-        		
         assert(allProductsName.size() > 0);
-        
         
         // Invoke driver.quit() after the test is done to indicate that the test is completed.
         driver.quit();

--- a/src/test/java/android/BrowserStackSample.java
+++ b/src/test/java/android/BrowserStackSample.java
@@ -1,65 +1,71 @@
 package android;
 
-import java.net.URL;
-import java.util.List;
-import java.util.function.Function;
-import java.net.MalformedURLException;
-
 import io.appium.java_client.AppiumBy;
-import org.openqa.selenium.WebDriver;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
-
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class BrowserStackSample {
 
-	public static void main(String[] args) throws MalformedURLException, InterruptedException {
-		
-    	DesiredCapabilities caps = new DesiredCapabilities();
-    	
-    	// Set your access credentials
-    	caps.setCapability("browserstack.user", "YOUR_USERNAME");
-		caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
-    	
-    	// Set URL of the application under test
-    	caps.setCapability("app", "bs://<app-id>");
-    	
-    	// Specify deviceName and platformName for testing
-    	caps.setCapability("deviceName", "Google Pixel 3");
-		caps.setCapability("platformName", "android");
-    	caps.setCapability("platformVersion", "9.0");
-        
-    	// Set other BrowserStack capabilities
-    	caps.setCapability("project", "First Java Project");
-    	caps.setCapability("build", "browserstack-build-1");
-    	caps.setCapability("name", "first_test");
-       
-    	// Initialise the remote Webdriver using BrowserStack remote URL
-    	// and desired capabilities defined above
-    	RemoteWebDriver driver = new RemoteWebDriver(new URL("http://hub.browserstack.com/wd/hub"), caps);
+  public static void main(String[] args)
+    throws MalformedURLException, InterruptedException {
+    DesiredCapabilities caps = new DesiredCapabilities();
 
-        // Test case for the BrowserStack sample Android app. 
-        // If you have uploaded your app, update the test case here. 
-        WebElement searchElement = (WebElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(
-            		AppiumBy.accessibilityId("Search Wikipedia")));
-        searchElement.click();
+    // Set your access credentials
+    caps.setCapability("browserstack.user", "YOUR_USERNAME");
+    caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
 
-		WebElement insertTextElement = (WebElement) new WebDriverWait(driver, 30).until(
-             ExpectedConditions.elementToBeClickable(
-            		 AppiumBy.id("org.wikipedia.alpha:id/search_src_text")));
-        insertTextElement.sendKeys("BrowserStack");
-        Thread.sleep(5000);
+    // Set URL of the application under test
+    caps.setCapability("app", "bs://<app-id>");
 
-        List<WebElement> allProductsName = driver.findElements(AppiumBy.className("android.widget.TextView"));
-        assert(allProductsName.size() > 0);
-        
-        // Invoke driver.quit() after the test is done to indicate that the test is completed.
-        driver.quit();
-		
-	}
+    // Specify deviceName and platformName for testing
+    caps.setCapability("deviceName", "Google Pixel 3");
+    caps.setCapability("platformName", "android");
+    caps.setCapability("platformVersion", "9.0");
 
+    // Set other BrowserStack capabilities
+    caps.setCapability("project", "First Java Project");
+    caps.setCapability("build", "browserstack-build-1");
+    caps.setCapability("name", "first_test");
+
+    // Initialise the remote Webdriver using BrowserStack remote URL
+    // and desired capabilities defined above
+    RemoteWebDriver driver = new RemoteWebDriver(
+      new URL("http://hub.browserstack.com/wd/hub"),
+      caps
+    );
+
+    // Test case for the BrowserStack sample Android app.
+    // If you have uploaded your app, update the test case here.
+    WebElement searchElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.accessibilityId("Search Wikipedia")
+        )
+      );
+    searchElement.click();
+
+    WebElement insertTextElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.id("org.wikipedia.alpha:id/search_src_text")
+        )
+      );
+    insertTextElement.sendKeys("BrowserStack");
+    Thread.sleep(5000);
+
+    List<WebElement> allProductsName = driver.findElements(
+      AppiumBy.className("android.widget.TextView")
+    );
+    assert (allProductsName.size() > 0);
+
+    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    driver.quit();
+  }
 }

--- a/src/test/java/android/BrowserStackSample.java
+++ b/src/test/java/android/BrowserStackSample.java
@@ -1,13 +1,14 @@
 package android;
 
 import io.appium.java_client.AppiumBy;
+import io.appium.java_client.android.AndroidDriver;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -16,27 +17,32 @@ public class BrowserStackSample {
   public static void main(String[] args)
     throws MalformedURLException, InterruptedException {
     DesiredCapabilities caps = new DesiredCapabilities();
-
+    HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
+    
     // Set your access credentials
-    caps.setCapability("browserstack.user", "YOUR_USERNAME");
-    caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
+    browserstackOptions.put("userName", "YOUR_USERNAME");
+    browserstackOptions.put("accessKey", "YOUR_ACCESS_KEY");
 
+    // Set other BrowserStack capabilities
+    browserstackOptions.put("appiumVersion", "1.22.0");
+    browserstackOptions.put("projectName", "First Java Project");
+    browserstackOptions.put("buildName", "browserstack-build-1");
+    browserstackOptions.put("sessionName", "first_test");
+    
+    // Passing browserstack caspabilities inside bstack:options
+    caps.setCapability("bstack:options", browserstackOptions);
+    
     // Set URL of the application under test
     caps.setCapability("app", "bs://<app-id>");
-
+    
     // Specify deviceName and platformName for testing
     caps.setCapability("deviceName", "Google Pixel 3");
     caps.setCapability("platformName", "android");
     caps.setCapability("platformVersion", "9.0");
 
-    // Set other BrowserStack capabilities
-    caps.setCapability("project", "First Java Project");
-    caps.setCapability("build", "browserstack-build-1");
-    caps.setCapability("name", "first_test");
-
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
-    RemoteWebDriver driver = new RemoteWebDriver(
+    AndroidDriver driver = new AndroidDriver(
       new URL("http://hub.browserstack.com/wd/hub"),
       caps
     );

--- a/src/test/java/android/BrowserStackSample.java
+++ b/src/test/java/android/BrowserStackSample.java
@@ -29,7 +29,7 @@ public class BrowserStackSample {
     browserstackOptions.put("buildName", "browserstack-build-1");
     browserstackOptions.put("sessionName", "first_test");
 
-    // Passing browserstack caspabilities inside bstack:options
+    // Passing browserstack capabilities inside bstack:options
     caps.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test

--- a/src/test/java/android/BrowserStackSample.java
+++ b/src/test/java/android/BrowserStackSample.java
@@ -18,7 +18,7 @@ public class BrowserStackSample {
     throws MalformedURLException, InterruptedException {
     DesiredCapabilities caps = new DesiredCapabilities();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
-    
+
     // Set your access credentials
     browserstackOptions.put("userName", "YOUR_USERNAME");
     browserstackOptions.put("accessKey", "YOUR_ACCESS_KEY");
@@ -28,13 +28,13 @@ public class BrowserStackSample {
     browserstackOptions.put("projectName", "First Java Project");
     browserstackOptions.put("buildName", "browserstack-build-1");
     browserstackOptions.put("sessionName", "first_test");
-    
+
     // Passing browserstack caspabilities inside bstack:options
     caps.setCapability("bstack:options", browserstackOptions);
-    
+
     // Set URL of the application under test
     caps.setCapability("app", "bs://<app-id>");
-    
+
     // Specify deviceName and platformName for testing
     caps.setCapability("deviceName", "Google Pixel 3");
     caps.setCapability("platformName", "android");
@@ -49,7 +49,10 @@ public class BrowserStackSample {
 
     // Test case for the BrowserStack sample Android app.
     // If you have uploaded your app, update the test case here.
-    WebElement searchElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    WebElement searchElement = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
     .until(
         ExpectedConditions.elementToBeClickable(
           AppiumBy.accessibilityId("Search Wikipedia")
@@ -57,7 +60,10 @@ public class BrowserStackSample {
       );
     searchElement.click();
 
-    WebElement insertTextElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    WebElement insertTextElement = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
     .until(
         ExpectedConditions.elementToBeClickable(
           AppiumBy.id("org.wikipedia.alpha:id/search_src_text")

--- a/src/test/java/android/BrowserStackSampleLocal.java
+++ b/src/test/java/android/BrowserStackSampleLocal.java
@@ -3,7 +3,6 @@ package android;
 import com.browserstack.local.Local;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
-
 import java.net.URL;
 import java.time.Duration;
 import java.util.*;
@@ -35,7 +34,7 @@ public class BrowserStackSampleLocal {
 
     DesiredCapabilities capabilities = new DesiredCapabilities();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
-  
+
     // Set your access credentials
     browserstackOptions.put("userName", userName);
     browserstackOptions.put("accessKey", accessKey);

--- a/src/test/java/android/BrowserStackSampleLocal.java
+++ b/src/test/java/android/BrowserStackSampleLocal.java
@@ -2,8 +2,13 @@ package android;
 
 import com.browserstack.local.Local;
 import java.net.URL; import java.util.*;
-import io.appium.java_client.MobileBy; import io.appium.java_client.android.*;
-import org.openqa.selenium.support.ui.*;import org.openqa.selenium.remote.*;
+import io.appium.java_client.android.*;
+import org.openqa.selenium.support.ui.*;
+import org.openqa.selenium.remote.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class BrowserStackSampleLocal {
 	
@@ -51,21 +56,20 @@ public class BrowserStackSampleLocal {
 
    	  // Initialise the remote Webdriver using BrowserStack remote URL
     	// and desired capabilities defined above
-      AndroidDriver<AndroidElement> driver = new AndroidDriver<AndroidElement>(
-        new URL("http://hub.browserstack.com/wd/hub"), capabilities);
+        RemoteWebDriver driver = new RemoteWebDriver(new URL("http://hub.browserstack.com/wd/hub"), capabilities);
 
         // Test case for the BrowserStack sample Android Local app. 
         // If you have uploaded your app, update the test case here.   
-        AndroidElement searchElement = (AndroidElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(MobileBy.id("com.example.android.basicnetworking:id/test_action")));
+        WebElement searchElement = new WebDriverWait(driver, 30).until(
+            ExpectedConditions.elementToBeClickable(By.id("com.example.android.basicnetworking:id/test_action")));
         searchElement.click();
-        AndroidElement insertTextElement = (AndroidElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(MobileBy.className("android.widget.TextView")));
+        WebElement insertTextElement = (WebElement) new WebDriverWait(driver, 30).until(
+            ExpectedConditions.elementToBeClickable(By.className("android.widget.TextView")));
 
-        AndroidElement testElement = null;
-        List<AndroidElement> allTextViewElements = driver.findElementsByClassName("android.widget.TextView");
+        WebElement testElement = null;
+        List<WebElement> allTextViewElements = driver.findElements(By.className("android.widget.TextView"));
         Thread.sleep(10);
-        for(AndroidElement textElement : allTextViewElements) {
+        for(WebElement textElement : allTextViewElements) {
           if(textElement.getText().contains("The active connection is")) {
             testElement = textElement;
           }

--- a/src/test/java/android/BrowserStackSampleLocal.java
+++ b/src/test/java/android/BrowserStackSampleLocal.java
@@ -2,12 +2,13 @@ package android;
 
 import com.browserstack.local.Local;
 import io.appium.java_client.AppiumBy;
+import io.appium.java_client.android.AndroidDriver;
+
 import java.net.URL;
 import java.time.Duration;
 import java.util.*;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.*;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.*;
 
 public class BrowserStackSampleLocal {
@@ -33,10 +34,23 @@ public class BrowserStackSampleLocal {
     setupLocal();
 
     DesiredCapabilities capabilities = new DesiredCapabilities();
-
+    HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
+  
     // Set your access credentials
-    capabilities.setCapability("browserstack.user", userName);
-    capabilities.setCapability("browserstack.key", accessKey);
+    browserstackOptions.put("userName", userName);
+    browserstackOptions.put("accessKey", accessKey);
+
+    // Set other BrowserStack capabilities
+    browserstackOptions.put("appiumVersion", "1.22.0");
+    browserstackOptions.put("projectName", "First Java Project");
+    browserstackOptions.put("buildName", "browserstack-build-1");
+    browserstackOptions.put("sessionName", "local_test");
+
+    // Set the browserstack.local capability to true
+    browserstackOptions.put("local", "true");
+
+    // Passing browserstack capabilities inside bstack:options
+    capabilities.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
     capabilities.setCapability("app", "bs://<app-id>");
@@ -46,14 +60,9 @@ public class BrowserStackSampleLocal {
     capabilities.setCapability("platformName", "android");
     capabilities.setCapability("platformVersion", "9.0");
 
-    // Set other BrowserStack capabilities
-    capabilities.setCapability("project", "First Java Project");
-    capabilities.setCapability("build", "browserstack-build-1");
-    capabilities.setCapability("name", "local_test");
-
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
-    RemoteWebDriver driver = new RemoteWebDriver(
+    AndroidDriver driver = new AndroidDriver(
       new URL("http://hub.browserstack.com/wd/hub"),
       capabilities
     );

--- a/src/test/java/android/BrowserStackSampleLocal.java
+++ b/src/test/java/android/BrowserStackSampleLocal.java
@@ -1,26 +1,26 @@
 package android;
 
 import com.browserstack.local.Local;
-import java.net.URL; import java.util.*;
-import io.appium.java_client.android.*;
-import org.openqa.selenium.support.ui.*;
-import org.openqa.selenium.remote.*;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
+import io.appium.java_client.AppiumBy;
+import java.net.URL;
+import java.time.Duration;
+import java.util.*;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.*;
 
 public class BrowserStackSampleLocal {
-	
+
   private static Local localInstance;
   public static String userName = "YOUR_USERNAME";
   public static String accessKey = "YOUR_ACCESS_KEY";
-
 
   public static void setupLocal() throws Exception {
     localInstance = new Local();
     Map<String, String> options = new HashMap<String, String>();
     options.put("key", accessKey);
+    options.put("local", "true");
     localInstance.start(options);
   }
 
@@ -28,67 +28,79 @@ public class BrowserStackSampleLocal {
     localInstance.stop();
   }
 
-	public static void main(String[] args) throws Exception {
-      // Start the BrowserStack Local binary
-      setupLocal();
+  public static void main(String[] args) throws Exception {
+    // Start the BrowserStack Local binary
+    setupLocal();
 
-      DesiredCapabilities capabilities = new DesiredCapabilities();
+    DesiredCapabilities capabilities = new DesiredCapabilities();
 
-    	// Set your access credentials
-    	capabilities.setCapability("browserstack.user", userName);
-    	capabilities.setCapability("browserstack.key", accessKey);
+    // Set your access credentials
+    capabilities.setCapability("browserstack.user", userName);
+    capabilities.setCapability("browserstack.key", accessKey);
 
-    	// Set URL of the application under test
-    	capabilities.setCapability("app", "bs://<app-id>");
+    // Set URL of the application under test
+    capabilities.setCapability("app", "bs://<app-id>");
 
-    	// Specify device and os_version for testing
-    	capabilities.setCapability("device", "Google Pixel 3");
-    	capabilities.setCapability("os_version", "9.0");
+    // Specify device and os_version for testing
+    capabilities.setCapability("deviceName", "Google Pixel 3");
+    capabilities.setCapability("platformName", "android");
+    capabilities.setCapability("platformVersion", "9.0");
 
-      // Set the browserstack.local capability to true
-      capabilities.setCapability("browserstack.local", true);
+    // Set other BrowserStack capabilities
+    capabilities.setCapability("project", "First Java Project");
+    capabilities.setCapability("build", "browserstack-build-1");
+    capabilities.setCapability("name", "local_test");
 
-      // Set other BrowserStack capabilities
-    	capabilities.setCapability("project", "First Java Project");
-    	capabilities.setCapability("build", "browserstack-build-1");
-    	capabilities.setCapability("name", "local_test");
-       
+    // Initialise the remote Webdriver using BrowserStack remote URL
+    // and desired capabilities defined above
+    RemoteWebDriver driver = new RemoteWebDriver(
+      new URL("http://hub.browserstack.com/wd/hub"),
+      capabilities
+    );
 
-   	  // Initialise the remote Webdriver using BrowserStack remote URL
-    	// and desired capabilities defined above
-        RemoteWebDriver driver = new RemoteWebDriver(new URL("http://hub.browserstack.com/wd/hub"), capabilities);
+    // Test case for the BrowserStack sample Android Local app.
+    // If you have uploaded your app, update the test case here.
+    WebElement searchElement = new WebDriverWait(driver, Duration.ofSeconds(30))
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.id("com.example.android.basicnetworking:id/test_action")
+        )
+      );
+    searchElement.click();
 
-        // Test case for the BrowserStack sample Android Local app. 
-        // If you have uploaded your app, update the test case here.   
-        WebElement searchElement = new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(By.id("com.example.android.basicnetworking:id/test_action")));
-        searchElement.click();
-        WebElement insertTextElement = (WebElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(By.className("android.widget.TextView")));
+    WebElement insertTextElement = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.className("android.widget.TextView")
+        )
+      );
 
-        WebElement testElement = null;
-        List<WebElement> allTextViewElements = driver.findElements(By.className("android.widget.TextView"));
-        Thread.sleep(10);
-        for(WebElement textElement : allTextViewElements) {
-          if(textElement.getText().contains("The active connection is")) {
-            testElement = textElement;
-          }
-        }
+    WebElement testElement = null;
+    List<WebElement> allTextViewElements = driver.findElements(
+      AppiumBy.className("android.widget.TextView")
+    );
+    Thread.sleep(10);
+    for (WebElement textElement : allTextViewElements) {
+      if (textElement.getText().contains("The active connection is")) {
+        testElement = textElement;
+      }
+    }
 
-        if(testElement == null) {
-          throw new Error("Cannot find the needed TextView element from app");
-        }
-        String matchedString = testElement.getText();
-        System.out.println(matchedString);
-        assert(matchedString.contains("The active connection is wifi"));
-        assert(matchedString.contains("Up and running"));
+    if (testElement == null) {
+      throw new Error("Cannot find the needed TextView element from app");
+    }
+    String matchedString = testElement.getText();
+    System.out.println(matchedString);
+    assert (matchedString.contains("The active connection is wifi"));
+    assert (matchedString.contains("Up and running"));
 
-        // Invoke driver.quit() after the test is done to indicate that the test is completed.
-        driver.quit();
+    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    driver.quit();
 
-        // Stop the BrowserStack Local binary
-        tearDownLocal();
-
-	}
-
+    // Stop the BrowserStack Local binary
+    tearDownLocal();
+  }
 }

--- a/src/test/java/ios/BrowserStackSample.java
+++ b/src/test/java/ios/BrowserStackSample.java
@@ -16,50 +16,50 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 public class BrowserStackSample {
 
 	public static void main(String[] args) throws MalformedURLException, InterruptedException {
-   	DesiredCapabilities caps = new DesiredCapabilities();
-    	
-    	// Set your access credentials
-    	caps.setCapability("browserstack.user", "YOUR_USERNAME");
-    	caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
+        
+        DesiredCapabilities caps = new DesiredCapabilities();
+            
+        // Set your access credentials
+        caps.setCapability("browserstack.user", "YOUR_USERNAME");
+		caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
     	
     	// Set URL of the application under test
     	caps.setCapability("app", "bs://<app-id>");
-    	
-    	// Specify device and os_version for testing
-    	caps.setCapability("device", "iPhone 11 Pro");
-    	caps.setCapability("os_version", "13");
         
-    	// Set other BrowserStack capabilities
-    	caps.setCapability("project", "First Java Project");
-    	caps.setCapability("build", "browserstack-build-1");
-    	caps.setCapability("name", "first_test");
-    	
-    	
-    	// Initialise the remote Webdriver using BrowserStack remote URL
-    	// and desired capabilities defined above
+        // Specify device and os_version for testing
+        caps.setCapability("deviceName", "iPhone 11 Pro");
+        caps.setCapability("platformName", "ios");
+    	caps.setCapability("platformVersion", "13");
+        
+        // Set other BrowserStack capabilities
+        caps.setCapability("project", "First Java Project");
+        caps.setCapability("build", "browserstack-build-1");
+        caps.setCapability("name", "first_test");
+        
+        // Initialise the remote Webdriver using BrowserStack remote URL
+        // and desired capabilities defined above
         RemoteWebDriver driver = new RemoteWebDriver(
-        		new URL("http://hub-cloud.browserstack.com/wd/hub"), caps);
+                new URL("http://hub-cloud.browserstack.com/wd/hub"), caps);
         
-
         // Test case for the BrowserStack sample iOS app. 
         // If you have uploaded your app, update the test case here. 
         WebElement textButton = (WebElement) new WebDriverWait(driver, 30).until(
             ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Button")));
         textButton.click();
+
         WebElement textInput = (WebElement) new WebDriverWait(driver, 30).until(
             ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Input")));
         textInput.sendKeys("hello@browserstack.com");
         Thread.sleep(5000);
+
         WebElement textOutput = (WebElement) new WebDriverWait(driver, 30).until(
                 ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Output")));
         if(textOutput != null && textOutput.getText().equals("hello@browserstack.com"))
             assert(true);
         else
             assert(false);  
-    
+
         // Invoke driver.quit() after the test is done to indicate that the test is completed.
         driver.quit();
-
-	}
-
+    }
 }

--- a/src/test/java/ios/BrowserStackSample.java
+++ b/src/test/java/ios/BrowserStackSample.java
@@ -2,12 +2,10 @@ package ios;
 
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.ios.IOSDriver;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.HashMap;
-
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -19,7 +17,7 @@ public class BrowserStackSample {
     throws MalformedURLException, InterruptedException {
     DesiredCapabilities caps = new DesiredCapabilities();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
-  
+
     // Set your access credentials
     browserstackOptions.put("userName", "YOUR_USERNAME");
     browserstackOptions.put("accessKey", "YOUR_ACCESS_KEY");
@@ -29,7 +27,7 @@ public class BrowserStackSample {
     browserstackOptions.put("projectName", "First Java Project");
     browserstackOptions.put("buildName", "browserstack-build-1");
     browserstackOptions.put("sessionName", "first_test");
-    
+
     // Passing browserstack caspabilities inside bstack:options
     caps.setCapability("bstack:options", browserstackOptions);
 
@@ -40,7 +38,7 @@ public class BrowserStackSample {
     caps.setCapability("deviceName", "iPhone 11 Pro");
     caps.setCapability("platformName", "ios");
     caps.setCapability("platformVersion", "13");
-    
+
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
     IOSDriver driver = new IOSDriver(
@@ -50,7 +48,10 @@ public class BrowserStackSample {
 
     // Test case for the BrowserStack sample iOS app.
     // If you have uploaded your app, update the test case here.
-    WebElement textButton = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    WebElement textButton = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
     .until(
         ExpectedConditions.elementToBeClickable(
           AppiumBy.accessibilityId("Text Button")
@@ -58,7 +59,10 @@ public class BrowserStackSample {
       );
     textButton.click();
 
-    WebElement textInput = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    WebElement textInput = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
     .until(
         ExpectedConditions.elementToBeClickable(
           AppiumBy.accessibilityId("Text Input")
@@ -67,7 +71,10 @@ public class BrowserStackSample {
     textInput.sendKeys("hello@browserstack.com");
     Thread.sleep(5000);
 
-    WebElement textOutput = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    WebElement textOutput = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
     .until(
         ExpectedConditions.elementToBeClickable(
           AppiumBy.accessibilityId("Text Output")

--- a/src/test/java/ios/BrowserStackSample.java
+++ b/src/test/java/ios/BrowserStackSample.java
@@ -8,9 +8,10 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import io.appium.java_client.MobileBy;
-import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.ios.IOSElement;
+import io.appium.java_client.AppiumBy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class BrowserStackSample {
 
@@ -36,21 +37,21 @@ public class BrowserStackSample {
     	
     	// Initialise the remote Webdriver using BrowserStack remote URL
     	// and desired capabilities defined above
-        IOSDriver<IOSElement> driver = new IOSDriver<IOSElement>(
+        RemoteWebDriver driver = new RemoteWebDriver(
         		new URL("http://hub-cloud.browserstack.com/wd/hub"), caps);
         
 
         // Test case for the BrowserStack sample iOS app. 
         // If you have uploaded your app, update the test case here. 
-        IOSElement textButton = (IOSElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(MobileBy.AccessibilityId("Text Button")));
+        WebElement textButton = (WebElement) new WebDriverWait(driver, 30).until(
+            ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Button")));
         textButton.click();
-        IOSElement textInput = (IOSElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(MobileBy.AccessibilityId("Text Input")));
+        WebElement textInput = (WebElement) new WebDriverWait(driver, 30).until(
+            ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Input")));
         textInput.sendKeys("hello@browserstack.com");
         Thread.sleep(5000);
-        IOSElement textOutput = (IOSElement) new WebDriverWait(driver, 30).until(
-                ExpectedConditions.elementToBeClickable(MobileBy.AccessibilityId("Text Output")));
+        WebElement textOutput = (WebElement) new WebDriverWait(driver, 30).until(
+                ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Output")));
         if(textOutput != null && textOutput.getText().equals("hello@browserstack.com"))
             assert(true);
         else

--- a/src/test/java/ios/BrowserStackSample.java
+++ b/src/test/java/ios/BrowserStackSample.java
@@ -1,13 +1,15 @@
 package ios;
 
 import io.appium.java_client.AppiumBy;
+import io.appium.java_client.ios.IOSDriver;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
+import java.util.HashMap;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -16,10 +18,20 @@ public class BrowserStackSample {
   public static void main(String[] args)
     throws MalformedURLException, InterruptedException {
     DesiredCapabilities caps = new DesiredCapabilities();
-
+    HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
+  
     // Set your access credentials
-    caps.setCapability("browserstack.user", "YOUR_USERNAME");
-    caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
+    browserstackOptions.put("userName", "YOUR_USERNAME");
+    browserstackOptions.put("accessKey", "YOUR_ACCESS_KEY");
+
+    // Set other BrowserStack capabilities
+    browserstackOptions.put("appiumVersion", "1.22.0");
+    browserstackOptions.put("projectName", "First Java Project");
+    browserstackOptions.put("buildName", "browserstack-build-1");
+    browserstackOptions.put("sessionName", "first_test");
+    
+    // Passing browserstack caspabilities inside bstack:options
+    caps.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
     caps.setCapability("app", "bs://<app-id>");
@@ -28,16 +40,11 @@ public class BrowserStackSample {
     caps.setCapability("deviceName", "iPhone 11 Pro");
     caps.setCapability("platformName", "ios");
     caps.setCapability("platformVersion", "13");
-
-    // Set other BrowserStack capabilities
-    caps.setCapability("project", "First Java Project");
-    caps.setCapability("build", "browserstack-build-1");
-    caps.setCapability("name", "first_test");
-
+    
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
-    RemoteWebDriver driver = new RemoteWebDriver(
-      new URL("http://hub-cloud.browserstack.com/wd/hub"),
+    IOSDriver driver = new IOSDriver(
+      new URL("http://hub.browserstack.com/wd/hub"),
       caps
     );
 

--- a/src/test/java/ios/BrowserStackSample.java
+++ b/src/test/java/ios/BrowserStackSample.java
@@ -28,7 +28,7 @@ public class BrowserStackSample {
     browserstackOptions.put("buildName", "browserstack-build-1");
     browserstackOptions.put("sessionName", "first_test");
 
-    // Passing browserstack caspabilities inside bstack:options
+    // Passing browserstack capabilities inside bstack:options
     caps.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test

--- a/src/test/java/ios/BrowserStackSample.java
+++ b/src/test/java/ios/BrowserStackSample.java
@@ -1,65 +1,77 @@
 package ios;
 
-import java.net.URL;
-import java.util.List;
-import java.net.MalformedURLException;
-
-import org.openqa.selenium.support.ui.WebDriverWait;
-import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-
 import io.appium.java_client.AppiumBy;
-import org.openqa.selenium.WebDriver;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class BrowserStackSample {
 
-	public static void main(String[] args) throws MalformedURLException, InterruptedException {
-        
-        DesiredCapabilities caps = new DesiredCapabilities();
-            
-        // Set your access credentials
-        caps.setCapability("browserstack.user", "YOUR_USERNAME");
-		caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
-    	
-    	// Set URL of the application under test
-    	caps.setCapability("app", "bs://<app-id>");
-        
-        // Specify device and os_version for testing
-        caps.setCapability("deviceName", "iPhone 11 Pro");
-        caps.setCapability("platformName", "ios");
-    	caps.setCapability("platformVersion", "13");
-        
-        // Set other BrowserStack capabilities
-        caps.setCapability("project", "First Java Project");
-        caps.setCapability("build", "browserstack-build-1");
-        caps.setCapability("name", "first_test");
-        
-        // Initialise the remote Webdriver using BrowserStack remote URL
-        // and desired capabilities defined above
-        RemoteWebDriver driver = new RemoteWebDriver(
-                new URL("http://hub-cloud.browserstack.com/wd/hub"), caps);
-        
-        // Test case for the BrowserStack sample iOS app. 
-        // If you have uploaded your app, update the test case here. 
-        WebElement textButton = (WebElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Button")));
-        textButton.click();
+  public static void main(String[] args)
+    throws MalformedURLException, InterruptedException {
+    DesiredCapabilities caps = new DesiredCapabilities();
 
-        WebElement textInput = (WebElement) new WebDriverWait(driver, 30).until(
-            ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Input")));
-        textInput.sendKeys("hello@browserstack.com");
-        Thread.sleep(5000);
+    // Set your access credentials
+    caps.setCapability("browserstack.user", "YOUR_USERNAME");
+    caps.setCapability("browserstack.key", "YOUR_ACCESS_KEY");
 
-        WebElement textOutput = (WebElement) new WebDriverWait(driver, 30).until(
-                ExpectedConditions.elementToBeClickable(AppiumBy.accessibilityId("Text Output")));
-        if(textOutput != null && textOutput.getText().equals("hello@browserstack.com"))
-            assert(true);
-        else
-            assert(false);  
+    // Set URL of the application under test
+    caps.setCapability("app", "bs://<app-id>");
 
-        // Invoke driver.quit() after the test is done to indicate that the test is completed.
-        driver.quit();
-    }
+    // Specify device and os_version for testing
+    caps.setCapability("deviceName", "iPhone 11 Pro");
+    caps.setCapability("platformName", "ios");
+    caps.setCapability("platformVersion", "13");
+
+    // Set other BrowserStack capabilities
+    caps.setCapability("project", "First Java Project");
+    caps.setCapability("build", "browserstack-build-1");
+    caps.setCapability("name", "first_test");
+
+    // Initialise the remote Webdriver using BrowserStack remote URL
+    // and desired capabilities defined above
+    RemoteWebDriver driver = new RemoteWebDriver(
+      new URL("http://hub-cloud.browserstack.com/wd/hub"),
+      caps
+    );
+
+    // Test case for the BrowserStack sample iOS app.
+    // If you have uploaded your app, update the test case here.
+    WebElement textButton = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.accessibilityId("Text Button")
+        )
+      );
+    textButton.click();
+
+    WebElement textInput = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.accessibilityId("Text Input")
+        )
+      );
+    textInput.sendKeys("hello@browserstack.com");
+    Thread.sleep(5000);
+
+    WebElement textOutput = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.accessibilityId("Text Output")
+        )
+      );
+    if (
+      textOutput != null &&
+      textOutput.getText().equals("hello@browserstack.com")
+    ) assert (true); else assert (false);
+
+    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    driver.quit();
+  }
 }

--- a/src/test/java/ios/BrowserStackSampleLocal.java
+++ b/src/test/java/ios/BrowserStackSampleLocal.java
@@ -2,6 +2,8 @@ package ios;
 
 import com.browserstack.local.Local;
 import io.appium.java_client.AppiumBy;
+import io.appium.java_client.ios.IOSDriver;
+
 import java.io.File;
 import java.net.URL;
 import java.time.Duration;
@@ -11,7 +13,6 @@ import org.openqa.selenium.*;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.*;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.*;
 
 public class BrowserStackSampleLocal {
@@ -37,30 +38,35 @@ public class BrowserStackSampleLocal {
     setupLocal();
 
     DesiredCapabilities capabilities = new DesiredCapabilities();
-
+    HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
+  
     // Set your access credentials
-    capabilities.setCapability("browserstack.user", userName);
-    capabilities.setCapability("browserstack.key", accessKey);
+    browserstackOptions.put("userName", userName);
+    browserstackOptions.put("accessKey", accessKey);
+
+    // Set other BrowserStack capabilities
+    browserstackOptions.put("appiumVersion", "1.22.0");
+    browserstackOptions.put("projectName", "First Java Project");
+    browserstackOptions.put("buildName", "browserstack-build-1");
+    browserstackOptions.put("sessionName", "local_test");
+
+    // Set the browserstack.local capability to true
+    browserstackOptions.put("local", "true");
+
+    // Passing browserstack capabilities inside bstack:options
+    capabilities.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
-    capabilities.setCapability("app", "<app-id>");
+    capabilities.setCapability("app", "bs://<app-id>");
 
     // Specify device and os_version for testing
     capabilities.setCapability("deviceName", "iPhone 11 Pro");
     capabilities.setCapability("platformName", "ios");
     capabilities.setCapability("platformVersion", "13");
 
-    // Set the browserstack.local capability to true
-    capabilities.setCapability("browserstack.local", true);
-
-    // Set other BrowserStack capabilities
-    capabilities.setCapability("project", "First Java Project");
-    capabilities.setCapability("build", "browserstack-build-1");
-    capabilities.setCapability("name", "local_test");
-
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
-    RemoteWebDriver driver = new RemoteWebDriver(
+    IOSDriver driver = new IOSDriver(
       new URL("http://hub.browserstack.com/wd/hub"),
       capabilities
     );

--- a/src/test/java/ios/BrowserStackSampleLocal.java
+++ b/src/test/java/ios/BrowserStackSampleLocal.java
@@ -3,7 +3,6 @@ package ios;
 import com.browserstack.local.Local;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.ios.IOSDriver;
-
 import java.io.File;
 import java.net.URL;
 import java.time.Duration;
@@ -39,7 +38,7 @@ public class BrowserStackSampleLocal {
 
     DesiredCapabilities capabilities = new DesiredCapabilities();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
-  
+
     // Set your access credentials
     browserstackOptions.put("userName", userName);
     browserstackOptions.put("accessKey", accessKey);

--- a/src/test/java/ios/BrowserStackSampleLocal.java
+++ b/src/test/java/ios/BrowserStackSampleLocal.java
@@ -1,99 +1,124 @@
 package ios;
 
 import com.browserstack.local.Local;
-import java.net.URL; import java.io.File; import java.util.*;
+import io.appium.java_client.AppiumBy;
+import java.io.File;
+import java.net.URL;
+import java.time.Duration;
+import java.util.*;
 import org.apache.commons.io.FileUtils;
-import io.appium.java_client.ios.*;
 import org.openqa.selenium.*;
-import org.openqa.selenium.support.ui.*;import org.openqa.selenium.remote.*;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.*;
 
 public class BrowserStackSampleLocal {
-	
-    private static Local localInstance;
-    public static String userName = "YOUR_USERNAME";
-    public static String accessKey = "YOUR_ACCESS_KEY";
-  
 
-    public static void setupLocal() throws Exception {
-      localInstance = new Local();
-      Map<String, String> options = new HashMap<String, String>();
-      options.put("key", accessKey);
-      localInstance.start(options);
-    }
+  private static Local localInstance;
+  public static String userName = "YOUR_USERNAME";
+  public static String accessKey = "YOUR_ACCESS_KEY";
 
-    public static void tearDownLocal() throws Exception {
-      localInstance.stop();
-    }
+  public static void setupLocal() throws Exception {
+    localInstance = new Local();
+    Map<String, String> options = new HashMap<String, String>();
+    options.put("key", accessKey);
+    options.put("local", "true");
+    localInstance.start(options);
+  }
 
+  public static void tearDownLocal() throws Exception {
+    localInstance.stop();
+  }
 
-	public static void main(String[] args) throws Exception {
-        // Start the BrowserStack Local binary
-        setupLocal();
+  public static void main(String[] args) throws Exception {
+    // Start the BrowserStack Local binary
+    setupLocal();
 
-        DesiredCapabilities capabilities = new DesiredCapabilities();
+    DesiredCapabilities capabilities = new DesiredCapabilities();
 
-        // Set your access credentials
-    	  capabilities.setCapability("browserstack.user", userName);
-        capabilities.setCapability("browserstack.key", accessKey);
-        
-        // Set URL of the application under test
-       capabilities.setCapability("app", "bs://<app-id>");
-       
-       // Specify device and os_version for testing
-       capabilities.setCapability("device", "iPhone 11 Pro");
-       capabilities.setCapability("os_version", "13");
+    // Set your access credentials
+    capabilities.setCapability("browserstack.user", userName);
+    capabilities.setCapability("browserstack.key", accessKey);
 
-      // Set the browserstack.local capability to true
-      capabilities.setCapability("browserstack.local", true);
+    // Set URL of the application under test
+    capabilities.setCapability("app", "<app-id>");
 
-      // Set other BrowserStack capabilities
-    	capabilities.setCapability("project", "First Java Project");
-    	capabilities.setCapability("build", "browserstack-build-1");
-    	capabilities.setCapability("name", "local_test");
-        
-   	  // Initialise the remote Webdriver using BrowserStack remote URL
-      // and desired capabilities defined above
-      RemoteWebDriver driver = new RemoteWebDriver(
-        new URL("http://hub.browserstack.com/wd/hub"), capabilities);
+    // Specify device and os_version for testing
+    capabilities.setCapability("deviceName", "iPhone 11 Pro");
+    capabilities.setCapability("platformName", "ios");
+    capabilities.setCapability("platformVersion", "13");
 
-        // Test case for the BrowserStack sample iOS Local app. 
-        // If you have uploaded your app, update the test case here.   
-        WebElement testButton = (WebElement) new WebDriverWait(driver, 30).until(
-          ExpectedConditions.elementToBeClickable(By.xpath("//*[@content-desc='TestBrowserStackLocal']")));
-        testButton.click();
-        
-        WebDriverWait wait = new WebDriverWait(driver, 30);
-        wait.until(new ExpectedCondition<Boolean>() {
-          @Override
-          public Boolean apply(WebDriver d) {
-            String result = d.findElement(By.xpath("//*[@content-desc='ResultBrowserStackLocal']")).getAttribute("value");
-            return result != null && result.length() > 0;
-          }
-        });
-        WebElement resultElement = (WebElement) driver.findElement(By.xpath("//*[@content-desc='ResultBrowserStackLocal']"));
+    // Set the browserstack.local capability to true
+    capabilities.setCapability("browserstack.local", true);
 
-        String resultString = resultElement.getText().toLowerCase();
-        System.out.println(resultString);
-        if(resultString.contains("not working")) {
-          File scrFile = (File) ((TakesScreenshot)driver).getScreenshotAs(OutputType.FILE);
-          FileUtils.copyFile(scrFile, new File(System.getProperty("user.dir") + "/screenshot.png"));
-          System.out.println("Screenshot stored at " + System.getProperty("user.dir") + "/screenshot.png");
-          throw new Error("Unexpected BrowserStackLocal test result");
+    // Set other BrowserStack capabilities
+    capabilities.setCapability("project", "First Java Project");
+    capabilities.setCapability("build", "browserstack-build-1");
+    capabilities.setCapability("name", "local_test");
+
+    // Initialise the remote Webdriver using BrowserStack remote URL
+    // and desired capabilities defined above
+    RemoteWebDriver driver = new RemoteWebDriver(
+      new URL("http://hub.browserstack.com/wd/hub"),
+      capabilities
+    );
+
+    // Test case for the BrowserStack sample iOS Local app.
+    // If you have uploaded your app, update the test case here.
+    WebElement testButton = (WebElement) new WebDriverWait(
+      driver,
+      Duration.ofSeconds(30)
+    )
+    .until(
+        ExpectedConditions.elementToBeClickable(
+          AppiumBy.accessibilityId("TestBrowserStackLocal")
+        )
+      );
+    testButton.click();
+
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30));
+    wait.until(
+      new ExpectedCondition<Boolean>() {
+        @Override
+        public Boolean apply(WebDriver d) {
+          String result = d
+            .findElement(AppiumBy.accessibilityId("ResultBrowserStackLocal"))
+            .getAttribute("value");
+          return result != null && result.length() > 0;
         }
+      }
+    );
+    WebElement resultElement = (WebElement) driver.findElement(
+      AppiumBy.accessibilityId("ResultBrowserStackLocal")
+    );
 
-        String expectedString = "Up and running";
-        assert(resultString.contains(expectedString.toLowerCase()));
+    String resultString = resultElement.getText().toLowerCase();
+    System.out.println(resultString);
+    if (resultString.contains("not working")) {
+      File scrFile = (File) ((TakesScreenshot) driver).getScreenshotAs(
+          OutputType.FILE
+        );
+      FileUtils.copyFile(
+        scrFile,
+        new File(System.getProperty("user.dir") + "/screenshot.png")
+      );
+      System.out.println(
+        "Screenshot stored at " +
+        System.getProperty("user.dir") +
+        "/screenshot.png"
+      );
+      throw new Error("Unexpected BrowserStackLocal test result");
+    }
 
-        // Invoke driver.quit() after the test is done to indicate that the test is completed.
-        driver.quit();
-        
-        // Stop the BrowserStack Local binary
-        tearDownLocal();
-		
-	}
+    String expectedString = "Up and running";
+    assert (resultString.contains(expectedString.toLowerCase()));
 
+    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    driver.quit();
+
+    // Stop the BrowserStack Local binary
+    tearDownLocal();
+  }
 }

--- a/src/test/java/ios/BrowserStackSampleLocal.java
+++ b/src/test/java/ios/BrowserStackSampleLocal.java
@@ -3,9 +3,13 @@ package ios;
 import com.browserstack.local.Local;
 import java.net.URL; import java.io.File; import java.util.*;
 import org.apache.commons.io.FileUtils;
-import io.appium.java_client.MobileBy; import io.appium.java_client.ios.*;
+import io.appium.java_client.ios.*;
 import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.*;import org.openqa.selenium.remote.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class BrowserStackSampleLocal {
 	
@@ -53,24 +57,24 @@ public class BrowserStackSampleLocal {
         
    	  // Initialise the remote Webdriver using BrowserStack remote URL
       // and desired capabilities defined above
-      IOSDriver<IOSElement> driver = new IOSDriver<IOSElement>(
+      RemoteWebDriver driver = new RemoteWebDriver(
         new URL("http://hub.browserstack.com/wd/hub"), capabilities);
 
         // Test case for the BrowserStack sample iOS Local app. 
         // If you have uploaded your app, update the test case here.   
-        IOSElement testButton = (IOSElement) new WebDriverWait(driver, 30).until(
-          ExpectedConditions.elementToBeClickable(MobileBy.AccessibilityId("TestBrowserStackLocal")));
+        WebElement testButton = (WebElement) new WebDriverWait(driver, 30).until(
+          ExpectedConditions.elementToBeClickable(By.xpath("//*[@content-desc='TestBrowserStackLocal']")));
         testButton.click();
-
+        
         WebDriverWait wait = new WebDriverWait(driver, 30);
         wait.until(new ExpectedCondition<Boolean>() {
           @Override
           public Boolean apply(WebDriver d) {
-            String result = d.findElement(MobileBy.AccessibilityId("ResultBrowserStackLocal")).getAttribute("value");
+            String result = d.findElement(By.xpath("//*[@content-desc='ResultBrowserStackLocal']")).getAttribute("value");
             return result != null && result.length() > 0;
           }
         });
-        IOSElement resultElement = (IOSElement) driver.findElement(MobileBy.AccessibilityId("ResultBrowserStackLocal"));
+        WebElement resultElement = (WebElement) driver.findElement(By.xpath("//*[@content-desc='ResultBrowserStackLocal']"));
 
         String resultString = resultElement.getText().toLowerCase();
         System.out.println(resultString);


### PR DESCRIPTION
Added changes in existing testcases to work with java-client version 8.0.0

**Changes**

- [x] Updated java-client version to 8.0.0
- [x] Removed AndroidElement and IosElement and replaced with WebElement
- [x] Removed MobileBy and replaced with AppiumBy
- [x] W3C compliant

**Breaking changes**

- AppiumBy is available with java-client 8.0.0 . For java-client < 8.0.0, MobileBy can be used.
- WebDriverWait constructor requires time to be passed as a type Duration. So with java-client 8.0.0, pass wait time as a new Duration
Refer this for tracking changes in java-client 8.0.0 documentation \
 [v7-to-v8-migration-guide](https://github.com/appium/java-client/blob/master/docs/v7-to-v8-migration-guide.md#mobileelement)