### PR TITLE
Updated the pom to install the latest Appium

### DIFF
--- a/java_8/pom.xml
+++ b/java_8/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>io.appium</groupId>
 			<artifactId>java-client</artifactId>
-			<version>8.0.0</version>
+			<version>8.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.browserstack</groupId>


### PR DESCRIPTION
The Appium Java-Client 8.0.0 is resulting in Appium object String to object Platform cast exception issue here: https://github.com/appium/java-client/issues/1701

Fix is to update to the Appium Java-Client 8.1.1.