### PR TITLE
use options class instead deprecated DesiredCapabilities

### DIFF
--- a/java_8/README.md
+++ b/java_8/README.md
@@ -1,5 +1,5 @@
 | [Using Java 7 client with MJSONWP protocol](../java_7) | Using Java 8 client with w3c protocol |
-|------------------------------------------------------- | ------------------------------------- |
+| ------------------------------------------------------ | ------------------------------------- |
 
 # java-appium-app-browserstack
 
@@ -12,13 +12,13 @@ This repository demonstrates how to run Appium Java tests on BrowserStack App Au
 1. Java 8+ (JDK)
 
 - If Java is not installed, follow these instructions:
-    - For Windows, download latest java version from [here](https://java.com/en/download/) and run the installer executable
-    - For Mac and Linux, run `java -version` to see what java version is pre-installed. If you want a different version download from [here](https://java.com/en/download/)
+  - For Windows, download latest java version from [here](https://java.com/en/download/) and run the installer executable
+  - For Mac and Linux, run `java -version` to see what java version is pre-installed. If you want a different version download from [here](https://java.com/en/download/)
 
 2. Maven
 
-    - If Maven is not downloaded, download it from [here](https://maven.apache.org/download.cgi)
-    - For installation, follow the instructions [here](https://maven.apache.org/install.html)
+   - If Maven is not downloaded, download it from [here](https://maven.apache.org/download.cgi)
+   - For installation, follow the instructions [here](https://maven.apache.org/install.html)
 
 ### Install the dependencies
 
@@ -35,24 +35,22 @@ Getting Started with Appium tests in Java on BrowserStack couldn't be easier!
 ### For java-client 8.0.0 and above
 
 - Any BrowserStack capability passed outside bstack:options will not be honoured \
-[Browserstack Capability Builder](https://www.browserstack.com/app-automate/capabilities?tag=w3c)
+  [Browserstack Capability Builder](https://www.browserstack.com/app-automate/capabilities?tag=w3c)
 
 - AppiumBy is available with java-client 8.0.0 as MobileBy is depreceated . For java-client < 8.0.0, MobileBy can be used.
 
 - DefaultGenericMobileElement class has been removed completely together with its descendants (MobileElement, IOSElement, AndroidElement etc.). Use WebElement instead.
 
 - WebDriverWait constructor requires time to be passed as a type Duration. So with java-client 8.0.0, pass wait time as a new Duration
-    **java-client v-7.0.0**
-    ```
-     WebElement searchElement = (WebElement) new WebDriverWait(driver, 30)
-    ```
-    
-    **java-client v-8.0.0**
-    ```
-     import java.time.Duration;
-     WebElement searchElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
-    ```
-    
+  **java-client v-7.0.0**
+  ```
+   WebElement searchElement = (WebElement) new WebDriverWait(driver, 30)
+  ```
+  **java-client v-8.0.0**
+  ```
+   import java.time.Duration;
+   WebElement searchElement = (WebElement) new WebDriverWait(driver, Duration.ofSeconds(30))
+  ```
   Refer this for tracking changes in java-client 8.0.0 documentation - [v7-to-v8-migration-guide](https://github.com/appium/java-client/blob/master/docs/v7-to-v8-migration-guide.md#mobileelement)
 
 ### Run your first test :
@@ -85,17 +83,17 @@ Open `BrowserStackSample.java` file in the `android` directory or `ios` director
 
 - To run the test, use the following command in the base directory :
 
-    - For Android test, run
+  - For Android test, run
 
-    ```cmd
-    mvn test -P android-first-test
-    ```
+  ```cmd
+  mvn test -P android-first-test
+  ```
 
-    - For iOS test, run
+  - For iOS test, run
 
-    ```cmd
-    mvn test -P ios-first-test
-    ```
+  ```cmd
+  mvn test -P ios-first-test
+  ```
 
 - You can access the test execution results, and debugging information such as video recording, network logs on [App Automate dashboard](https://app-automate.browserstack.com/dashboard)
 
@@ -121,22 +119,7 @@ Ensure that @ symbol is prepended to the file path in the above request. Please 
 
 Local Testing is a BrowserStack feature that helps you test mobile apps that access resources hosted in development or testing environments during automated test execution
 
-**i. Setup Browserstack Local Testing connection :**
-
-Check the releases page to download the binary / native application [Browserstack Local Releases](https://www.browserstack.com/docs/local-testing/releases-and-downloads)
-
-- Option 1
-    - Use Browserstack Local Binary - [Local Binary](https://www.browserstack.com/docs/app-automate/appium/getting-started/java/local-testing)
-- Option 2
-    - Use Browserstack native application - [Local Native App](https://www.browserstack.com/docs/local-testing/local-app-upgrade-guide)
-
-
-NOTE : If you're unable to run the LocalTesting Binary / Native application due to Apple permission issues, go to \
-    ```
-        System preferences -> Security and privacy -> General -> Allow app
-    ```
-
-**ii. Open `BrowserStackSampleLocal.java` file in the `android` or `ios` directory :**
+Open `BrowserStackSampleLocal.java` file in the `android` or `ios` directory :
 
 - Replace `YOUR_USERNAME` & `YOUR_ACCESS_KEY` with your BrowserStack access credentials. Get your BrowserStack access credentials from [here](https://www.browserstack.com/accounts/settings)
 
@@ -144,26 +127,25 @@ NOTE : If you're unable to run the LocalTesting Binary / Native application due 
 
 - Set the device and OS version
 
-- Ensure that `browserstack.local` capability is set to `true`. Within the test script, there is code snippet that automatically establishes Local Testing connection to BrowserStack servers using Java binding for BrowserStack Local.
+- Ensure that `local` capability is set to `true`. Within the test script, there is code snippet that automatically establishes Local Testing connection to BrowserStack servers using Java binding for BrowserStack Local.
 
 - If you have uploaded your own app update the test case
 
 - To run the test, use the following command in the base directory :
 
-    - For Android test, run
+  - For Android test, run
 
-    ```cmd
-    mvn test -P android-local-test
-    ```
+  ```cmd
+  mvn test -P android-local-test
+  ```
 
-    - For iOS test, run
+  - For iOS test, run
 
-    ```cmd
-    mvn test -P ios-local-test
-    ```
+  ```cmd
+  mvn test -P ios-local-test
+  ```
 
 - You can access the test execution results, and debugging information such as video recording, network logs on [App Automate dashboard](https://app-automate.browserstack.com/dashboard)
-
 
 ## Integration with other Java frameworks
 

--- a/java_8/pom.xml
+++ b/java_8/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>io.appium</groupId>
 			<artifactId>java-client</artifactId>
-			<version>8.0.0</version>
+			<version>8.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.browserstack</groupId>

--- a/java_8/src/test/java/android/BrowserStackSample.java
+++ b/java_8/src/test/java/android/BrowserStackSample.java
@@ -2,21 +2,21 @@ package android;
 
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.options.UiAutomator2Options;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class BrowserStackSample {
 
   public static void main(String[] args)
-    throws MalformedURLException, InterruptedException {
-    DesiredCapabilities caps = new DesiredCapabilities();
+      throws MalformedURLException, InterruptedException {
+    UiAutomator2Options options = new UiAutomator2Options();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
 
     // Set your access credentials
@@ -27,57 +27,50 @@ public class BrowserStackSample {
     browserstackOptions.put("appiumVersion", "1.22.0");
     browserstackOptions.put("projectName", "First Java Project");
     browserstackOptions.put("buildName", "browserstack-build-1");
-    browserstackOptions.put("sessionName", "first_test");
+    browserstackOptions.put("sessionName", "BStack first_test");
 
     // Passing browserstack capabilities inside bstack:options
-    caps.setCapability("bstack:options", browserstackOptions);
+    options.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
-    caps.setCapability("app", "bs://<app-id>");
+    options.setCapability("app", "bs://<app-id>");
 
     // Specify deviceName and platformName for testing
-    caps.setCapability("deviceName", "Google Pixel 3");
-    caps.setCapability("platformName", "android");
-    caps.setCapability("platformVersion", "9.0");
+    options.setCapability("deviceName", "Google Pixel 3");
+    options.setCapability("platformName", "android");
+    options.setCapability("platformVersion", "9.0");
 
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
     AndroidDriver driver = new AndroidDriver(
-      new URL("http://hub.browserstack.com/wd/hub"),
-      caps
-    );
+        new URL("http://hub.browserstack.com/wd/hub"),
+        options);
 
     // Test case for the BrowserStack sample Android app.
     // If you have uploaded your app, update the test case here.
     WebElement searchElement = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.accessibilityId("Search Wikipedia")
-        )
-      );
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.accessibilityId("Search Wikipedia")));
     searchElement.click();
 
     WebElement insertTextElement = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.id("org.wikipedia.alpha:id/search_src_text")
-        )
-      );
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.id("org.wikipedia.alpha:id/search_src_text")));
     insertTextElement.sendKeys("BrowserStack");
     Thread.sleep(5000);
 
     List<WebElement> allProductsName = driver.findElements(
-      AppiumBy.className("android.widget.TextView")
-    );
+        AppiumBy.className("android.widget.TextView"));
     assert (allProductsName.size() > 0);
 
-    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    // Invoke driver.quit() after the test is done to indicate that the test is
+    // completed.
     driver.quit();
   }
 }

--- a/java_8/src/test/java/android/BrowserStackSampleLocal.java
+++ b/java_8/src/test/java/android/BrowserStackSampleLocal.java
@@ -3,11 +3,11 @@ package android;
 import com.browserstack.local.Local;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.options.UiAutomator2Options;
 import java.net.URL;
 import java.time.Duration;
 import java.util.*;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.*;
 import org.openqa.selenium.support.ui.*;
 
 public class BrowserStackSampleLocal {
@@ -18,7 +18,7 @@ public class BrowserStackSampleLocal {
 
   public static void setupLocal() throws Exception {
     localInstance = new Local();
-    Map<String, String> options = new HashMap<String, String>();
+    HashMap<String, String> options = new HashMap<String, String>();
     options.put("key", accessKey);
     options.put("local", "true");
     localInstance.start(options);
@@ -32,7 +32,7 @@ public class BrowserStackSampleLocal {
     // Start the BrowserStack Local binary
     setupLocal();
 
-    DesiredCapabilities capabilities = new DesiredCapabilities();
+    UiAutomator2Options options = new UiAutomator2Options();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
 
     // Set your access credentials
@@ -43,53 +43,46 @@ public class BrowserStackSampleLocal {
     browserstackOptions.put("appiumVersion", "1.22.0");
     browserstackOptions.put("projectName", "First Java Project");
     browserstackOptions.put("buildName", "browserstack-build-1");
-    browserstackOptions.put("sessionName", "local_test");
+    browserstackOptions.put("sessionName", "BStack local_test");
 
     // Set the browserstack.local capability to true
     browserstackOptions.put("local", "true");
 
     // Passing browserstack capabilities inside bstack:options
-    capabilities.setCapability("bstack:options", browserstackOptions);
+    options.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
-    capabilities.setCapability("app", "bs://<app-id>");
+    options.setCapability("app", "bs://<app-id>");
 
     // Specify device and os_version for testing
-    capabilities.setCapability("deviceName", "Google Pixel 3");
-    capabilities.setCapability("platformName", "android");
-    capabilities.setCapability("platformVersion", "9.0");
+    options.setCapability("deviceName", "Google Pixel 3");
+    options.setCapability("platformName", "android");
+    options.setCapability("platformVersion", "9.0");
 
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
     AndroidDriver driver = new AndroidDriver(
-      new URL("http://hub.browserstack.com/wd/hub"),
-      capabilities
-    );
+        new URL("http://hub.browserstack.com/wd/hub"),
+        options);
 
     // Test case for the BrowserStack sample Android Local app.
     // If you have uploaded your app, update the test case here.
     WebElement searchElement = new WebDriverWait(driver, Duration.ofSeconds(30))
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.id("com.example.android.basicnetworking:id/test_action")
-        )
-      );
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.id("com.example.android.basicnetworking:id/test_action")));
     searchElement.click();
 
     WebElement insertTextElement = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.className("android.widget.TextView")
-        )
-      );
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.className("android.widget.TextView")));
 
     WebElement testElement = null;
     List<WebElement> allTextViewElements = driver.findElements(
-      AppiumBy.className("android.widget.TextView")
-    );
+        AppiumBy.className("android.widget.TextView"));
     Thread.sleep(10);
     for (WebElement textElement : allTextViewElements) {
       if (textElement.getText().contains("The active connection is")) {
@@ -105,7 +98,8 @@ public class BrowserStackSampleLocal {
     assert (matchedString.contains("The active connection is wifi"));
     assert (matchedString.contains("Up and running"));
 
-    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    // Invoke driver.quit() after the test is done to indicate that the test is
+    // completed.
     driver.quit();
 
     // Stop the BrowserStack Local binary

--- a/java_8/src/test/java/ios/BrowserStackSample.java
+++ b/java_8/src/test/java/ios/BrowserStackSample.java
@@ -2,20 +2,20 @@ package ios;
 
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.ios.options.XCUITestOptions;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.HashMap;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class BrowserStackSample {
 
   public static void main(String[] args)
-    throws MalformedURLException, InterruptedException {
-    DesiredCapabilities caps = new DesiredCapabilities();
+      throws MalformedURLException, InterruptedException {
+    XCUITestOptions options = new XCUITestOptions();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
 
     // Set your access credentials
@@ -26,66 +26,58 @@ public class BrowserStackSample {
     browserstackOptions.put("appiumVersion", "1.22.0");
     browserstackOptions.put("projectName", "First Java Project");
     browserstackOptions.put("buildName", "browserstack-build-1");
-    browserstackOptions.put("sessionName", "first_test");
+    browserstackOptions.put("sessionName", "BStack first_test");
 
     // Passing browserstack capabilities inside bstack:options
-    caps.setCapability("bstack:options", browserstackOptions);
+    options.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
-    caps.setCapability("app", "bs://<app-id>");
+    options.setCapability("app", "bs://<app-id>");
 
     // Specify device and os_version for testing
-    caps.setCapability("deviceName", "iPhone 12");
-    caps.setCapability("platformName", "ios");
-    caps.setCapability("platformVersion", "13");
+    options.setCapability("deviceName", "iPhone 11 Pro");
+    options.setCapability("platformName", "ios");
+    options.setCapability("platformVersion", "13");
 
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
     IOSDriver driver = new IOSDriver(
-      new URL("http://hub.browserstack.com/wd/hub"),
-      caps
-    );
+        new URL("http://hub.browserstack.com/wd/hub"),
+        options);
 
     // Test case for the BrowserStack sample iOS app.
     // If you have uploaded your app, update the test case here.
     WebElement textButton = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.accessibilityId("Text Button")
-        )
-      );
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.accessibilityId("Text Button")));
     textButton.click();
 
     WebElement textInput = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.accessibilityId("Text Input")
-        )
-      );
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.accessibilityId("Text Input")));
     textInput.sendKeys("hello@browserstack.com");
     Thread.sleep(5000);
 
     WebElement textOutput = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.accessibilityId("Text Output")
-        )
-      );
-    if (
-      textOutput != null &&
-      textOutput.getText().equals("hello@browserstack.com")
-    ) assert (true); else assert (false);
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.accessibilityId("Text Output")));
+    if (textOutput != null &&
+        textOutput.getText().equals("hello@browserstack.com"))
+      assert (true);
+    else
+      assert (false);
 
-    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    // Invoke driver.quit() after the test is done to indicate that the test is
+    // completed.
     driver.quit();
   }
 }

--- a/java_8/src/test/java/ios/BrowserStackSampleLocal.java
+++ b/java_8/src/test/java/ios/BrowserStackSampleLocal.java
@@ -3,6 +3,7 @@ package ios;
 import com.browserstack.local.Local;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.ios.options.XCUITestOptions;
 import java.io.File;
 import java.net.URL;
 import java.time.Duration;
@@ -11,7 +12,6 @@ import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.*;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.*;
 import org.openqa.selenium.support.ui.*;
 
 public class BrowserStackSampleLocal {
@@ -22,9 +22,8 @@ public class BrowserStackSampleLocal {
 
   public static void setupLocal() throws Exception {
     localInstance = new Local();
-    Map<String, String> options = new HashMap<String, String>();
+    HashMap<String, String> options = new HashMap<String, String>();
     options.put("key", accessKey);
-    options.put("local", "true");
     localInstance.start(options);
   }
 
@@ -36,7 +35,7 @@ public class BrowserStackSampleLocal {
     // Start the BrowserStack Local binary
     setupLocal();
 
-    DesiredCapabilities capabilities = new DesiredCapabilities();
+    XCUITestOptions options = new XCUITestOptions();
     HashMap<String, Object> browserstackOptions = new HashMap<String, Object>();
 
     // Set your access credentials
@@ -47,80 +46,72 @@ public class BrowserStackSampleLocal {
     browserstackOptions.put("appiumVersion", "1.22.0");
     browserstackOptions.put("projectName", "First Java Project");
     browserstackOptions.put("buildName", "browserstack-build-1");
-    browserstackOptions.put("sessionName", "local_test");
+    browserstackOptions.put("sessionName", "BStack local_test");
 
     // Set the browserstack.local capability to true
     browserstackOptions.put("local", "true");
 
     // Passing browserstack capabilities inside bstack:options
-    capabilities.setCapability("bstack:options", browserstackOptions);
+    options.setCapability("bstack:options", browserstackOptions);
 
     // Set URL of the application under test
-    capabilities.setCapability("app", "bs://<app-id>");
+    options.setCapability("app", "bs://<app-id>");
 
     // Specify device and os_version for testing
-    capabilities.setCapability("deviceName", "iPhone 12");
-    capabilities.setCapability("platformName", "ios");
-    capabilities.setCapability("platformVersion", "13");
+    options.setCapability("deviceName", "iPhone XS");
+    options.setCapability("platformName", "ios");
+    options.setCapability("platformVersion", "12");
 
     // Initialise the remote Webdriver using BrowserStack remote URL
     // and desired capabilities defined above
     IOSDriver driver = new IOSDriver(
-      new URL("http://hub.browserstack.com/wd/hub"),
-      capabilities
-    );
+        new URL("http://hub.browserstack.com/wd/hub"),
+        options);
 
     // Test case for the BrowserStack sample iOS Local app.
     // If you have uploaded your app, update the test case here.
     WebElement testButton = (WebElement) new WebDriverWait(
-      driver,
-      Duration.ofSeconds(30)
-    )
-    .until(
-        ExpectedConditions.elementToBeClickable(
-          AppiumBy.accessibilityId("TestBrowserStackLocal")
-        )
-      );
+        driver,
+        Duration.ofSeconds(30))
+        .until(
+            ExpectedConditions.elementToBeClickable(
+                AppiumBy.accessibilityId("TestBrowserStackLocal")));
     testButton.click();
 
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30));
     wait.until(
-      new ExpectedCondition<Boolean>() {
-        @Override
-        public Boolean apply(WebDriver d) {
-          String result = d
-            .findElement(AppiumBy.accessibilityId("ResultBrowserStackLocal"))
-            .getAttribute("value");
-          return result != null && result.length() > 0;
-        }
-      }
-    );
+        new ExpectedCondition<Boolean>() {
+          @Override
+          public Boolean apply(WebDriver d) {
+            String result = d
+                .findElement(AppiumBy.accessibilityId("ResultBrowserStackLocal"))
+                .getAttribute("value");
+            return result != null && result.length() > 0;
+          }
+        });
     WebElement resultElement = (WebElement) driver.findElement(
-      AppiumBy.accessibilityId("ResultBrowserStackLocal")
-    );
+        AppiumBy.accessibilityId("ResultBrowserStackLocal"));
 
     String resultString = resultElement.getText().toLowerCase();
     System.out.println(resultString);
     if (resultString.contains("not working")) {
       File scrFile = (File) ((TakesScreenshot) driver).getScreenshotAs(
-          OutputType.FILE
-        );
+          OutputType.FILE);
       FileUtils.copyFile(
-        scrFile,
-        new File(System.getProperty("user.dir") + "/screenshot.png")
-      );
+          scrFile,
+          new File(System.getProperty("user.dir") + "/screenshot.png"));
       System.out.println(
-        "Screenshot stored at " +
-        System.getProperty("user.dir") +
-        "/screenshot.png"
-      );
+          "Screenshot stored at " +
+              System.getProperty("user.dir") +
+              "/screenshot.png");
       throw new Error("Unexpected BrowserStackLocal test result");
     }
 
     String expectedString = "Up and running";
     assert (resultString.contains(expectedString.toLowerCase()));
 
-    // Invoke driver.quit() after the test is done to indicate that the test is completed.
+    // Invoke driver.quit() after the test is done to indicate that the test is
+    // completed.
     driver.quit();
 
     // Stop the BrowserStack Local binary


### PR DESCRIPTION
JIRA: https://browserstack.atlassian.net/browse/ASI-4226
This PR:
- Uses latest python appium client
- Replace deprecated DesiredCapabilities with Options class
- Remove unnecessary local setup instruction